### PR TITLE
Moved junit dependency to the top level project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,10 +54,10 @@ local.properties
 .worksheet
 
 ### Eclipse Patch ###
-# Eclipse Core		
+# Eclipse Core
 .project
 
-# JDT-specific (Eclipse Java Development Tools)		
+# JDT-specific (Eclipse Java Development Tools)
 .classpath
 
 ### Intellij ###
@@ -176,3 +176,7 @@ gradle-app.setting
 # End of https://www.gitignore.io/api/gradle
 
 .vscode/*
+
+# The gradle wrapper is added in the repo, but can be rebuilt by IDEs, and we don't want those changes to be committed
+# each time
+gradle/wrapper/*

--- a/build.gradle
+++ b/build.gradle
@@ -25,4 +25,10 @@ subprojects {
 
 	// Force compilers to use UTF-8
 	compileJava.options.encoding = 'UTF-8'
+
+	dependencies  {
+		// Dependencies for running the code. testCompile means dependencies used for tests, while compile means
+		// dependencies used for production code
+		testCompile 'junit:junit:5.0'
+	}
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,8 +1,5 @@
-
 apply plugin: 'java-library'
 
-dependencies  {
-	// Dependencies for running the code. testCompile means dependencies used for tests, while compile means
-	// dependencies used for production code
-	testCompile 'junit:junit:5.0'
+dependencies {
+
 }


### PR DESCRIPTION
Moved the junit dependency to the top level project rather than being in each subproject individually.