### PR TITLE
Fix dependencies not being included in mindstorms jar

### DIFF
--- a/lego/build.gradle
+++ b/lego/build.gradle
@@ -5,7 +5,7 @@ mainClassName = 'uk.ac.cam.cl.group_project.delta.lego.MainClass'
 
 dependencies {
 	compile project(':common')
-	compile group: 'com.github.bdeneuter', name: 'lejos-ev3-api', version: '0.9.1-beta'
+	compileOnly group: 'com.github.bdeneuter', name: 'lejos-ev3-api', version: '0.9.1-beta'
 }
 
 // Define the connection to the mindstorms
@@ -22,6 +22,10 @@ remotes {
 jar {
 	manifest {
 		attributes 'Main-Class': mainClassName
+	}
+	// Include all the dependencies
+	from {
+		configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
 	}
 }
 


### PR DESCRIPTION
This makes sure that the dependencies (currently just common) are included in the jar for the mindstorms. It only affects mindstorms code.

We might benefit from a parallel branch structure so that stuff like this wouldn't need to be merged into master straight away, it could be merged into lego for other lego code to use, then merged into master with other changes later.